### PR TITLE
Prevent the gradient element from creating a horizontal scroll

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,7 +23,7 @@ const { description, title } = Astro.props
     <title>{title}</title>
   </head>
 
-  <body class="relative">
+  <body class="relative overflow-x-hidden">
     <div
       class="absolute top-0 bottom-0 z-[-2] min-h-screen w-screen bg-neutral-950 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"
     >

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,9 +23,9 @@ const { description, title } = Astro.props
     <title>{title}</title>
   </head>
 
-  <body class="relative overflow-x-hidden">
+  <body class="relative">
     <div
-      class="absolute top-0 bottom-0 z-[-2] min-h-screen w-screen bg-neutral-950 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"
+      class="absolute top-0 bottom-0 z-[-2] min-h-screen w-full bg-neutral-950 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"
     >
     </div>
     <Header />


### PR DESCRIPTION
By adding overflow-x-hidden class to the body element, we can prevent the horizontal scroll created by gradient element