### PR TITLE
use explicit text-white in layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,7 +23,7 @@ const { description, title } = Astro.props
     <title>{title}</title>
   </head>
 
-  <body class="relative">
+  <body class="relative text-white">
     <div
       class="absolute top-0 bottom-0 z-[-2] min-h-screen w-full bg-neutral-950 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"
     >


### PR DESCRIPTION
Use explicit text-white in main layout to avoid dark text in browser light-mode

before (light mode)
![image](https://github.com/midudev/porfolio.dev/assets/42481580/1efd5dbf-0893-45a8-8d05-0476cd35d75b)

after
![image](https://github.com/midudev/porfolio.dev/assets/42481580/6a2e2889-be6f-4cc0-88cf-3e20243867bc)
