### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+package-lock.json


### PR DESCRIPTION
The autogenerated file package-lock.json wasn't at the .gitignore, it could be merged unintentionally in a PR.