### PR TITLE
Mejores prácticas y mejora al SEO

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,10 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig } from 'astro/config'
+import tailwind from "@astrojs/tailwind"
 
-import tailwind from "@astrojs/tailwind";
+import robotsTxt from "astro-robots-txt"
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [tailwind()]
-});
+  integrations: [tailwind(), robotsTxt()],
+  site: 'https://porfolio.dev/'
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/tailwind": "5.1.0",
     "@fontsource-variable/onest": "5.0.2",
     "astro": "4.1.3",
+    "astro-robots-txt": "^1.0.0",
     "tailwindcss": "3.4.1",
     "typescript": "5.3.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   astro:
     specifier: 4.1.3
     version: 4.1.3(typescript@5.3.3)
+  astro-robots-txt:
+    specifier: ^1.0.0
+    version: 1.0.0
   tailwindcss:
     specifier: 3.4.1
     version: 3.4.1
@@ -1008,6 +1011,13 @@ packages:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
     dev: false
 
+  /astro-robots-txt@1.0.0:
+    resolution: {integrity: sha512-6JQSLid4gMhoWjOm85UHLkgrw0+hHIjnJVIUqxjU2D6feKlVyYukMNYjH44ZDZBK1P8hNxd33PgWlHzCASvedA==}
+    dependencies:
+      valid-filename: 4.0.0
+      zod: 3.22.4
+    dev: false
+
   /astro@4.1.3(typescript@5.3.3):
     resolution: {integrity: sha512-9i8l0mEnpAOAi9F3DMkHGaZ4q56TGtt71XaAxhPXAlhZrVR/6ruobCyYdYwL1Fo0ATpuGXdaod1I7FFxFMcQbw==}
     engines: {node: '>=18.14.1', npm: '>=6.14.0'}
@@ -1658,6 +1668,11 @@ packages:
     resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
     dependencies:
       reusify: 1.0.4
+    dev: false
+
+  /filename-reserved-regex@3.0.0:
+    resolution: {integrity: sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 
   /fill-range@7.0.1:
@@ -3797,6 +3812,13 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
+
+  /valid-filename@4.0.0:
+    resolution: {integrity: sha512-VEYTpTVPMgO799f2wI7zWf0x2C54bPX6NAfbZ2Z8kZn76p+3rEYCTYVYzMUcVSMvakxMQTriBf24s3+WeXJtEg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      filename-reserved-regex: 3.0.0
     dev: false
 
   /vfile-location@5.0.2:

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -78,8 +78,10 @@ const navItems = [
     });
 
     // Cleanup function
-    window.onunload = () => {
-      observer.disconnect();
+    document.onvisibilitychange = () => {
+      if (document.visibilityState === "hidden") {
+        observer.disconnect();
+      }
     };
   });
 </script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />


### PR DESCRIPTION
# Para la sección de `Mejores prácticas`

La API de [`onunload`](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#browser_compatibility) está deprecada, lo cuál causa una baja significativa en la sección de mejores prácticas de `Lighthouse`:

![image](https://github.com/midudev/porfolio.dev/assets/35697365/b846559a-a022-4937-aebb-5497c562655f)

![image](https://github.com/midudev/porfolio.dev/assets/35697365/9f4de4a3-09bd-4a2a-8030-5cfd10b94e76)

Afortunadamente, el evento [`visibilitychange`](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event) es equivalente y compatible. Muy sencilla de implementar:

```diff
/* Header.astro */
// Cleanup function
+    document.onvisibilitychange = () => {
+      if (document.visibilityState === "hidden") {
+        observer.disconnect();
+      }
+    };
-    window.onunload = () => {
-      observer.disconnect();
-    };
```

# Para el SEO

A pesar de que `Lighthouse` nos da una puntuación de 100 en SEO en
la web de producción, al momento de la build, no se llega a esa puntuación:

![image](https://github.com/midudev/porfolio.dev/assets/35697365/50064cde-24f4-4d66-b85f-830114e78a81)

Esto se debe a que `Lighthouse` no tiene en cuenta el `robots.txt` de la web, y
por lo tanto, no sabe que la web está indexada. La solución es basta sencilla
ya que existe una integración de `Astro` que hace esto automáticamente agregando
una pequeña configuración en el `astro.config.mjs`:

```diff
/* astro.config.mjs */
export default defineConfig({
+   site: 'https://porfolio.dev',
    ...
})
```

That's all folks! 🐰
![image](https://github.com/midudev/porfolio.dev/assets/35697365/4a0b1e27-e5a1-441b-94ac-28cbf917ee17)

# Algunas referencias

- [Feature: Deprecate unload event](https://chromestatus.com/feature/5579556305502208)
- [Uses deprecated APIs](https://developer.chrome.com/docs/lighthouse/best-practices/deprecations/)
- [Document: visibilitychange event](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event)
- [Disable unload handlers by default and add Permissions-Policy to opt-in to enabling them.](https://github.com/fergald/docs/blob/master/explainers/permissions-policy-deprecate-unload.md#disable-unload-handlers-by-default-and-add-permissions-policy-to-opt-in-to-enabling-them)
- [astro-robots-txt](https://github.com/alextim/astro-lib/tree/main/packages/astro-robots-txt#readme)
- [Astro integrations](https://astro.build/integrations/)
