### PR TITLE
Fix IntersectionObserver behavior on visibility change

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -79,6 +79,10 @@ const navItems = [
     document.onvisibilitychange = () => {
       if (document.visibilityState === "hidden") {
         observer.disconnect()
+      } else {
+        sections.forEach((section) => {
+          observer.observe(section)
+        })
       }
     }
   })


### PR DESCRIPTION
Fixing broken header navigation highlight when user clicks on another browser tab.

Before:
![Captura desde 2024-02-06 15-03-28](https://github.com/midudev/porfolio.dev/assets/56077652/a561bd7e-5255-484c-a818-8dd8f63d967c)
![Captura desde 2024-02-06 15-03-55](https://github.com/midudev/porfolio.dev/assets/56077652/99f7695c-aeb9-466c-91d3-17f8debf3746)

After:
![Captura desde 2024-02-06 15-06-10](https://github.com/midudev/porfolio.dev/assets/56077652/59a32578-3ced-4292-a6a4-9a871af4d2b8)
