### PR TITLE
Fix theme inconsistencies

### DIFF
--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -30,7 +30,7 @@
     </p>
   </div>
 
-  <img width="200" height="200" src="/me.png" alt={personalImageAlt} class="order-1 object-cover w-64 h-full p-1 bg-white md:order-2 rotate-3 lg:p-2 lg:w-64 aspect-square rounded-2xl dark:bg-yellow-500/5 ring-1 ring-white/20 " style="object-position: 50% 50%">
+  <img width="200" height="200" src="/me.png" alt={personalImageAlt} class="order-1 object-cover w-64 h-full p-1 md:order-2 rotate-3 lg:p-2 lg:w-64 aspect-square rounded-2xl bg-black/20 dark:bg-yellow-500/5 ring-1 ring-black/70 dark:ring-white/20 " style="object-position: 50% 50%">
 
 </article>
 

--- a/src/components/ExperienceItem.astro
+++ b/src/components/ExperienceItem.astro
@@ -13,7 +13,7 @@ const { title, company, description, link, date } = Astro.props
 ---
 
 <div
-  class="relative mx-12 pb-12 grid before:absolute before:left-[-35px] before:block before:h-full before:border-l-2 before:border-white/15 before:content-[''] md:grid-cols-5 md:gap-10 md:space-x-4]"
+  class="relative mx-12 pb-12 grid before:absolute before:left-[-35px] before:block before:h-full before:border-l-2 before:border-black/20 dark:before:border-white/15 before:content-[''] md:grid-cols-5 md:gap-10 md:space-x-4]"
 >
   <div class="relative pb-12 md:col-span-2">
     <div class="sticky top-0">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,7 @@ const currentYear = new Date().getFullYear()
 ---
 
 <footer
-  class="rounded-lg shadow m-4 bg-black/5 dark:bg-black/20 backdrop-blur-lg w-full mx-auto container lg:max-w-4xl md:max-w-2xl mb-10 flex justify-center"
+  class="rounded-lg shadow m-4 bg-black/5 dark:bg-white/10 dark:shadow-white/20 backdrop-blur-lg w-full mx-auto container lg:max-w-4xl md:max-w-2xl mb-10 flex justify-center"
 >
   <div
     class="w-full max-w-screen-xl mx-auto md:flex md:items-center md:justify-between"


### PR DESCRIPTION
Fix theme inconsistencies due to missing theme color properties in some components, which were affecting to:

- The experience vertical line in light mode.
- The footer container in dark mode.
- The about me image in light mode.

Before:
![image](https://github.com/midudev/porfolio.dev/assets/80907533/22e2ce1f-902a-4362-b4b7-cc79220c0127)
![image](https://github.com/midudev/porfolio.dev/assets/80907533/2f29d0f2-b20e-4c2b-939a-86d2cfd8438e)

After:
![image](https://github.com/midudev/porfolio.dev/assets/80907533/be082b52-d880-42ff-83f5-efe2a57888f6)
![image](https://github.com/midudev/porfolio.dev/assets/80907533/c155fffb-9584-4fe4-8f43-b853248f2cdd)
