### PR TITLE
Update SectionContainer.astro

### DIFF
--- a/src/components/SectionContainer.astro
+++ b/src/components/SectionContainer.astro
@@ -5,7 +5,7 @@ const { class: className, id } = Astro.props
 <section
   id={id}
   data-section={id}
-  class={`section ${className} w-full mx-auto container lg:max-w-4xl md:max-w-2xl`}
+  class={`section ${className} scroll-m-20 w-full mx-auto container lg:max-w-4xl md:max-w-2xl`}
 >
   <slot />
 </section>


### PR DESCRIPTION
scroll-m-# da un margen con respecto al viewport para cuando se navega a través nav así el nav no queda por encima del title de la section, lo aprendi viendo el codigo fuente de openai.sora que utiliza este estilo de nav. :)