### PR TITLE
Fixed theme switching bug related to page transitions.

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -8,6 +8,7 @@ const THEMES = ["Light", "Dark", "System"]
 
 <div class="relative ml-1 mr-1">
   <button
+    transition:persist
     id="theme-toggle-btn"
     class="appearance-none border-none flex hover:scale-125 transition"
   >
@@ -23,6 +24,7 @@ const THEMES = ["Light", "Dark", "System"]
     />
   </button>
   <div
+    transition:persist
     id="themes-menu"
     class="absolute hidden scale-80 top-8 right-0 text-sm p-1 min-w-[8rem] rounded-md border border-gray-100 bg-white/90 dark:bg-gray-900/90 dark:border-gray-500/20 shadow-[0_3px_10px_rgb(0,0,0,0.2)] backdrop-blur-md"
   >
@@ -111,5 +113,10 @@ const THEMES = ["Light", "Dark", "System"]
       localStorage.setItem("theme", e.target.innerText.toLowerCase().trim())
       updateTheme()
     })
+  })
+
+  document.addEventListener('astro:after-swap', () => {
+    updateTheme();
+    window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
   })
 </script>


### PR DESCRIPTION
**Issue ref:** https://github.com/midudev/porfolio.dev/issues/46

- [+] Se agregó `transition:persist` para indicar a Astro que mantenga el estado entre transiciones a los botones/dropdown de la funcionalidad de cambio de tema.
- [+] Se agregó un eventListener `astro:after-swap` que ayudará a refrescar el tema luego de una Transición entre páginas/ruta, debido a que en ciertas ocasiones no solo los botones se rompen, si no que el tema no se actualiza.
- [+] Adicionalmente movemos el scroll hasta arriba al cambiar de página/ruta para mostrar el contenido desde el inicio.

**Motivo del bug:**
El problema ocurre debido a las `<ViewTransitions/>` de Astro, justo al momento de redireccionar a otra página/ruta mediante un anchor tag.

**Finalmente:**
Ofrezco esta solución ya qué experimenté el mismo problema en mi porfolio incluso sin tener un Dropdown y solo ser un botón de ThemeToggle.

Espero sea de ayuda!