### PR TITLE
Update Header.astro

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -95,9 +95,16 @@ const navItems = [
     animation-range: 0 100px;
   }
 
+  nav {
+    @apply dark:bg-gray-800/90 bg-white/50;
+  }
+
   @keyframes nav-shadown {
+    0% {
+      @apply dark:bg-gray-800/0 bg-white/0;
+    }
     to {
-      @apply shadow-lg ring-1 backdrop-blur dark:bg-gray-800/90 bg-white/50 ring-white/10;
+      @apply shadow-lg ring-1 backdrop-blur ring-white/10;
     }
   }
 </style>


### PR DESCRIPTION
# Bug o error solucionado

Al parecer, hay un bug o algo así con Tailwind que impide que el fondo del nav correspondiente se aplique en modo oscuro. Por lo tanto, he modificado un poco el código para evitar que esto ocurra.

**Antes:**
---
![image](https://github.com/midudev/porfolio.dev/assets/110266536/0a4f92df-6d1e-42ca-95c1-d00599b0f87e)

**Despues:**
---
![image](https://github.com/midudev/porfolio.dev/assets/110266536/f3c134c3-f40a-4ca1-9a43-e9df0c6f9c48)


