### PR TITLE
Light mode support for projects buttons.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pnpm-debug.log*
 .DS_Store
 
 package-lock.json
+pnpm-lock.yaml

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -1,11 +1,11 @@
 ---
-const { href } = Astro.props
+const { href } = Astro.props;
 ---
 
 <a
-  href={href}
-  role="link"
-  class="inline-flex items-center justify-center gap-2 px-3 py-2 space-x-2 text-base text-white transition bg-gray-800 border border-gray-600 focus-visible:ring-yellow-500/80 text-md hover:bg-gray-800 hover:border-gray-900 group max-w-fit rounded-xl hover:text-white focus:outline-none focus-visible:outline-none focus-visible:ring focus-visible:ring-white focus-visible:ring-offset-2 active:bg-black"
+    href={href}
+    role="link"
+    class="inline-flex bg-gray-100 text-gray-800 border-gray-300 items-center justify-center gap-2 px-3 py-2 space-x-2 text-base transition dark:text-white dark:bg-gray-800 border dark:border-gray-600 focus-visible:ring-yellow-500/80 text-md hover:bg-gray-800 hover:border-gray-900 group max-w-fit rounded-xl hover:text-white focus:outline-none focus-visible:outline-none focus-visible:ring focus-visible:ring-white focus-visible:ring-offset-2 active:bg-black"
 >
-  <slot />
+    <slot />
 </a>


### PR DESCRIPTION
## Se agrega el soporte a botones blancos en la sección de proyectos, éstos previamente no se ajustaban al modo claro, haciendo que se vea raro.
### _Me basé en el SocialPill en el tema colores_.

### Previo:
![image](https://github.com/user-attachments/assets/b1105de7-0190-43c9-9111-b46eaa5d0510)
### Fix:
![image](https://github.com/user-attachments/assets/0d964443-7fb8-49bb-90df-a236d6ad812d)