### PR TITLE
Update Projects.astro: Updating the flexibility of the tags when ther…

### DIFF
--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -53,9 +53,9 @@ const PROJECTS = [
       {title}
     </h3>
     <div class="flex flex-wrap mt-2">
-      <ul class="flex flex-row mb-2 gap-x-2">
+      <ul class="flex flex-wrap mb-2 gap-x-2 justify-center">
           {tags.map((tag) => (
-            <li>
+            <li class="mb-2">
               <span
                 class={`flex gap-x-2 rounded-full text-xs ${tag.class} py-1 px-2 `}
               >


### PR DESCRIPTION
…e are more than 3 tags and that the background still covers the entire screen.

Cuando Agregue proyectos con 4 tags, el fondo de toda la página no abarcaba toda la pantalla en dispositivos celulares (Ejemplo: 276px de ancho), con estos cambios de clases de estilos tailwind se arregla esto.