### PR TITLE
Changed ThemeToggle.astro component to use Typescript instead of inline JS

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -65,6 +65,7 @@ const THEMES = ["Light", "Dark", "System"]
   const DARK: ThemePreference = "dark"
   const LIGHT: ThemePreference = "light"
   const SYSTEM: ThemePreference = "system"
+  const THEME_STORAGE_KEY = "theme"
 
   let remove: (() => void) | null = null
   const matchMedia = window.matchMedia("(prefers-color-scheme: dark)")
@@ -72,7 +73,7 @@ const THEMES = ["Light", "Dark", "System"]
 
   const getThemePreference = (): ThemePreference => {
     if (typeof localStorage !== "undefined") {
-      return (localStorage.getItem("theme") as ThemePreference) ?? SYSTEM
+      return (localStorage.getItem(THEME_STORAGE_KEY) as ThemePreference) ?? SYSTEM
     }
 
     return matchMedia.matches ? DARK : LIGHT
@@ -116,7 +117,7 @@ const THEMES = ["Light", "Dark", "System"]
     element.addEventListener("click", (e) => {
       const target = e.target as HTMLElement
       const theme = target.innerText.toLowerCase().trim() as ThemePreference
-      localStorage.setItem("theme", theme)
+      localStorage.setItem(THEME_STORAGE_KEY, theme)
       updateTheme()
     })
   })

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -99,7 +99,7 @@ const THEMES = ["Light", "Dark", "System"]
       (themePreference === SYSTEM && matchMedia.matches)
 
     updateIcon(themePreference)
-    document.documentElement.classList[isDark ? "add" : "remove"]("dark")
+    document.documentElement.classList.toggle("dark", isDark)
   }
 
   updateTheme()
@@ -109,7 +109,7 @@ const THEMES = ["Light", "Dark", "System"]
   document.getElementById("theme-toggle-btn")?.addEventListener("click", (e) => {
     e.stopPropagation()
     const isClosed = !themesMenu.classList.contains("open")
-    themesMenu.classList[isClosed ? "add" : "remove"]("open")
+    themesMenu.classList.toggle("open", isClosed)
   })
 
   document.querySelectorAll<HTMLLIElement>(".themes-menu-option").forEach((element) => {

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -59,12 +59,12 @@ const THEMES = ["Light", "Dark", "System"]
   }
 </style>
 
-<script is:inline>
-  let remove = null
+<script>
+  let remove: (() => void) | null = null
   const matchMedia = window.matchMedia("(prefers-color-scheme: dark)")
-  const themesMenu = document.getElementById("themes-menu")
+  const themesMenu = document.getElementById("themes-menu") as HTMLDivElement
 
-  const getThemePreference = () => {
+  const getThemePreference = (): string => {
     if (typeof localStorage !== "undefined") {
       return localStorage.getItem("theme") ?? "system"
     }
@@ -74,13 +74,13 @@ const THEMES = ["Light", "Dark", "System"]
       : "light"
   }
 
-  const updateIcon = (themePreference) => {
-    document.querySelectorAll(".theme-toggle-icon").forEach((element) => {
+  const updateIcon = (themePreference: string): void => {
+    document.querySelectorAll<HTMLElement>(".theme-toggle-icon").forEach((element) => {
       element.style.scale = element.id === themePreference ? "1" : "0"
     })
   }
 
-  const updateTheme = () => {
+  const updateTheme = (): void => {
     if (remove != null) {
       remove()
     }
@@ -102,15 +102,16 @@ const THEMES = ["Light", "Dark", "System"]
 
   document.addEventListener("click", () => themesMenu.classList.remove("open"))
 
-  document.getElementById("theme-toggle-btn").addEventListener("click", (e) => {
+  document.getElementById("theme-toggle-btn")?.addEventListener("click", (e) => {
     e.stopPropagation()
     const isClosed = !themesMenu.classList.contains("open")
     themesMenu.classList[isClosed ? "add" : "remove"]("open")
   })
 
-  document.querySelectorAll(".themes-menu-option").forEach((element) => {
+  document.querySelectorAll<HTMLLIElement>(".themes-menu-option").forEach((element) => {
     element.addEventListener("click", (e) => {
-      localStorage.setItem("theme", e.target.innerText.toLowerCase().trim())
+      const target = e.target as HTMLElement
+      localStorage.setItem("theme", target.innerText.toLowerCase().trim())
       updateTheme()
     })
   })

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -60,21 +60,25 @@ const THEMES = ["Light", "Dark", "System"]
 </style>
 
 <script>
+  type ThemePreference = "dark" | "light" | "system"
+
+  const DARK: ThemePreference = "dark"
+  const LIGHT: ThemePreference = "light"
+  const SYSTEM: ThemePreference = "system"
+
   let remove: (() => void) | null = null
   const matchMedia = window.matchMedia("(prefers-color-scheme: dark)")
   const themesMenu = document.getElementById("themes-menu") as HTMLDivElement
 
-  const getThemePreference = (): string => {
+  const getThemePreference = (): ThemePreference => {
     if (typeof localStorage !== "undefined") {
-      return localStorage.getItem("theme") ?? "system"
+      return (localStorage.getItem("theme") as ThemePreference) ?? SYSTEM
     }
 
-    return matchMedia.matches
-      ? "dark"
-      : "light"
+    return matchMedia.matches ? DARK : LIGHT
   }
 
-  const updateIcon = (themePreference: string): void => {
+  const updateIcon = (themePreference: ThemePreference): void => {
     document.querySelectorAll<HTMLElement>(".theme-toggle-icon").forEach((element) => {
       element.style.scale = element.id === themePreference ? "1" : "0"
     })
@@ -91,8 +95,8 @@ const THEMES = ["Light", "Dark", "System"]
 
     const themePreference = getThemePreference()
     const isDark =
-      themePreference === "dark" ||
-      (themePreference === "system" && matchMedia.matches)
+      themePreference === DARK ||
+      (themePreference === SYSTEM && matchMedia.matches)
 
     updateIcon(themePreference)
     document.documentElement.classList[isDark ? "add" : "remove"]("dark")
@@ -111,7 +115,8 @@ const THEMES = ["Light", "Dark", "System"]
   document.querySelectorAll<HTMLLIElement>(".themes-menu-option").forEach((element) => {
     element.addEventListener("click", (e) => {
       const target = e.target as HTMLElement
-      localStorage.setItem("theme", target.innerText.toLowerCase().trim())
+      const theme = target.innerText.toLowerCase().trim() as ThemePreference
+      localStorage.setItem("theme", theme)
       updateTheme()
     })
   })

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -69,7 +69,7 @@ const THEMES = ["Light", "Dark", "System"]
       return localStorage.getItem("theme") ?? "system"
     }
 
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
+    return matchMedia.matches
       ? "dark"
       : "light"
   }


### PR DESCRIPTION
This change includes the refactoring of ThemeToggle.astro component to use Typescript instead of inline JS as long as some other minor changes to the code (see in different commits).

This change also makes Astro minify the JS and slightly reduce the page size.

Not minified JS (actual):
<img width="941" alt="image" src="https://github.com/user-attachments/assets/bb005025-9ee4-4646-873f-4f6e7492868e" />

Minified JS is included in the /_astro/<id>.js file.