### PR TITLE
fix: overflow in Badge component in mobile layout (issue)

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -3,7 +3,7 @@
   <span
     class="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#51E4B8_0%,#21554E_50%,#51E4B8_100%)]"
   ></span>
-  <div class="inline-flex items-center justify-center w-full px-3 py-1 text-sm text-green-800 bg-green-100 rounded-full cursor-pointer dark:bg-gray-800 dark:text-white/80 backdrop-blur-3xl whitespace-nowrap">
+  <div class="inline-flex items-center justify-center w-full px-3 py-1 text-sm text-green-800 bg-green-100 rounded-full cursor-pointer dark:bg-gray-800 dark:text-white/80 backdrop-blur-3xl whitespace-normal">
     <slot />
   </div>
 </span>


### PR DESCRIPTION
### Description of changes

I worked on the open issue: **Background gradient cut off on mobile devices**.

#### Problem:
The issue occurs when the badge text is too long, causing the background to break on mobile view.

**Problem example:**

![image](https://github.com/user-attachments/assets/f51e2c4a-6aa7-4be7-9f77-4caf84388036)


#### Solution:
The `Badge.astro` file was edited, changing the `whitespace-nowrap` property to `whitespace-normal`. This allows the text to wrap automatically to fit the available width, preventing the design from breaking on mobile devices.

**Solution example:**

![image](https://github.com/user-attachments/assets/5ad6f1dc-848b-4280-9c44-b069729bb8c5)

