### PR TITLE
Corrige el símbolo de copyright en el pie de página

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,7 +9,7 @@ const currentYear = new Date().getFullYear()
     class="rounded-lg w-full max-w-screen-xl mx-auto md:flex md:items-center md:justify-between py-4"
   >
     <span class="text-sm sm:text-center text-zinc-800/90 dark:text-zinc-200/90"
-      >© {currentYear}
+      >&copy; {currentYear}
       <a href="https://midu.dev/" class="hover:underline">midudev</a>. Casi
       todos los derechos reservados
     </span>


### PR DESCRIPTION
Actualmente se usa "©", el fix es usar el item de html definido para eso "&copy;"