### PR TITLE
feat: Disable DarkReader

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,16 +1,16 @@
 ---
-import "@fontsource-variable/onest"
+import "@fontsource-variable/onest";
 
-import Header from "../components/Header.astro"
-import Footer from "../components/Footer.astro"
-import { ViewTransitions } from "astro:transitions"
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import { ViewTransitions } from "astro:transitions";
 
 interface Props {
-  title: string
-  description: string
+  title: string;
+  description: string;
 }
 
-const { description, title } = Astro.props
+const { description, title } = Astro.props;
 ---
 
 <!doctype html>
@@ -22,6 +22,7 @@ const { description, title } = Astro.props
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    <meta name="darkreader-lock" />
     <ViewTransitions />
   </head>
 


### PR DESCRIPTION
This PR adds a new meta tag to Starlight which prevents the extension DarkReader from manipulating the dark mode the portfolio provides (https://northstarthemes.com/blog/web-dev/disable-darkreader-on-site/#how-to-disable-darkreader-on-your-website).

I set the changeset to make this a minor change. Open for suggestions.

As a user of DarkReader, I find it pretty annoying to have to disable DarkReader for all pages that it doesn't detect the dark mode, as they are in dark mode by default and the DarkReader version makes them pretty ugly.