### PR TITLE
fix: resolve issues #46, #67 and #96

### DIFF
--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -44,7 +44,7 @@ const PROJECTS = [
     <article class="flex flex-col space-x-0 space-y-8 group md:flex-row md:space-x-8 md:space-y-0">
   <div class="w-full md:w-1/2">
     <div class="relative flex flex-col items-center col-span-6 row-span-5 gap-8 transition duration-500 ease-in-out transform shadow-xl overflow-clip rounded-xl sm:rounded-xl md:group-hover:-translate-y-1 md:group-hover:shadow-2xl lg:border lg:border-gray-800 lg:hover:border-gray-700 lg:hover:bg-gray-800/50">
-      <img alt="Recién llegado vs 5 años en Nueva Zelanda" class="object-cover object-top w-full h-56 transition duration-500 sm:h-full md:scale-110 md:group-hover:scale-105" loading="lazy" src={image} />
+      <img alt={title} class="object-cover object-top w-full h-56 transition duration-500 sm:h-full md:scale-110 md:group-hover:scale-105" loading="lazy" src={image} />
     </div>
   </div>
 

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -105,25 +105,36 @@ const THEMES = ["Light", "Dark", "System"]
 
   updateTheme()
 
-  document.addEventListener("click", () => themesMenu.classList.remove("open"))
+  let abortController: AbortController | null = null
 
-  document.getElementById("theme-toggle-btn")?.addEventListener("click", (e) => {
-    e.stopPropagation()
-    const isClosed = !themesMenu.classList.contains("open")
-    themesMenu.classList.toggle("open", isClosed)
-  })
+  const attachListeners = () => {
+    abortController?.abort()
+    abortController = new AbortController()
+    const { signal } = abortController
 
-  document.querySelectorAll<HTMLLIElement>(".themes-menu-option").forEach((element) => {
-    element.addEventListener("click", (e) => {
-      const target = e.target as HTMLElement
-      const theme = target.innerText.toLowerCase().trim() as ThemePreference
-      localStorage.setItem(THEME_STORAGE_KEY, theme)
-      updateTheme()
+    document.addEventListener("click", () => themesMenu.classList.remove("open"), { signal })
+
+    document.getElementById("theme-toggle-btn")?.addEventListener("click", (e) => {
+      e.stopPropagation()
+      const isClosed = !themesMenu.classList.contains("open")
+      themesMenu.classList.toggle("open", isClosed)
+    }, { signal })
+
+    document.querySelectorAll<HTMLLIElement>(".themes-menu-option").forEach((element) => {
+      element.addEventListener("click", (e) => {
+        const target = e.target as HTMLElement
+        const theme = target.innerText.toLowerCase().trim() as ThemePreference
+        localStorage.setItem(THEME_STORAGE_KEY, theme)
+        updateTheme()
+      }, { signal })
     })
-  })
+  }
+
+  attachListeners()
 
   document.addEventListener('astro:after-swap', () => {
     updateTheme();
+    attachListeners();
     window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
   })
 </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,7 +28,7 @@ const { description, title } = Astro.props;
 
   <body class="relative text-black dark:text-white">
     <div
-      class="absolute top-0 bottom-0 z-[-2] min-h-screen w-full bg-gray-50 dark:bg-gray-950
+      class="fixed inset-0 z-[-2] bg-gray-50 dark:bg-gray-950
       bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(217,216,255,0.5),rgba(255,255,255,0.9))]
       dark:bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"
     >


### PR DESCRIPTION
Fixes three open issues:

## #96 — Accesibilidad: alt text en imágenes de proyectos
El componente `Projects.astro` usaba un `alt` hardcodeado (`"Recién llegado vs 5 años en Nueva Zelanda"`) para todas las imágenes, violando WCAG 1.1.1.

**Fix:** se usa `alt={title}` para que cada imagen tenga su texto alternativo correcto.

## #67 — Gradiente de fondo cortado en móvil
El div de fondo usaba `position: absolute` con `min-h-screen`, lo que hacía que en móvil el gradiente se cortara cuando el viewport cambiaba (barra de dirección del navegador).

**Fix:** se cambia a `position: fixed` con `inset-0` para que el fondo siempre cubra todo el viewport visible.

## #46 — Dropdown del ThemeToggle se rompe al volver desde /components
Con Astro View Transitions y `transition:persist`, el script de `ThemeToggle.astro` se re-ejecutaba en cada navegación y acumulaba múltiples `addEventListener` sobre los mismos elementos del DOM persistidos, rompiendo el comportamiento del dropdown.

**Fix:** se usa un `AbortController` que cancela los listeners anteriores antes de volver a añadirlos en cada navegación (`astro:after-swap`).