### PR TITLE
fix: Removed sobre mi button

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,9 +18,6 @@ const currentYear = new Date().getFullYear()
       class="flex flex-wrap items-center mt-3 text-sm font-medium dark:text-white/90 sm:mt-0"
     >
       <li>
-        <a href="/#sobre-mi" class="hover:underline me-4 md:me-6">Sobre mí</a>
-      </li>
-      <li>
         <a id="contacto" href="mailto:miduga@gmail.com" class="hover:underline"
           >Contacto</a
         >


### PR DESCRIPTION
He eliminado el enlace “Sobre mí” en el footer porque la sección está visible en todo momento, por lo que resultaba redundante.

Como posible mejora, se podrían añadir enlaces a otras secciones o un botón para volver al inicio y mejorar la navegación.